### PR TITLE
DPI-2838 Pack flipDashboard in nix

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -5,5 +5,4 @@ pkgs.rPackages.buildRPackage {
   version = displayrUtils.extractRVersion (builtins.readFile ./DESCRIPTION); 
   src = ./.;
   description = "Tools that help when creating a Dashboard in Displayr, such as for filtering using comboxes.";
-
 }

--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,9 @@
+{ pkgs ? import <nixpkgs> {}, displayrUtils }:
+
+pkgs.rPackages.buildRPackage {
+  name = "flipDashboard";
+  version = displayrUtils.extractRVersion (builtins.readFile ./DESCRIPTION); 
+  src = ./.;
+  description = "Tools that help when creating a Dashboard in Displayr, such as for filtering using comboxes.";
+
+}


### PR DESCRIPTION
As part of the R Server CI/CD uplift, this task is to package flipDashboard in Nix to make R server CI/CD more reliable and reproducible. To build it, see https://github.com/Displayr/NixR